### PR TITLE
Improved styles

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-var url = window.location.href;
+const url = window.location.href;
 
-if(url.indexOf(".m.wikipedia") < 0)
-	window.location.href = url.replace(".wikipedia", "m.wikipedia");
+if(!url.includes(".m.wikipedia"))
+	window.location.href = url.replace(".wikipedia", ".m.wikipedia");

--- a/script.js
+++ b/script.js
@@ -1,7 +1,4 @@
-var http = window.location.href, position = http.indexOf(".m.wikipedia");
+var url = window.location.href;
 
-if(position < 0) {
-	position = http.indexOf(".wikipedia");
-	http = http.substring(0, position)+".m"+http.substring(position, http.length);
-	window.location.href = http;
-}
+if(url.indexOf(".m.wikipedia") < 0)
+	window.location.href = url.replace(".wikipedia", "m.wikipedia");

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-var http = window.location.href, position = http.indexOf("m.wikipedia");
+var http = window.location.href, position = http.indexOf(".m.wikipedia");
 
 if(position < 0) {
 	position = http.indexOf(".wikipedia");

--- a/style.css
+++ b/style.css
@@ -2,3 +2,28 @@
 	outline: none !important;
 	font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue","Helvetica", "Nimbus Sans L", "Arial", "Liberation Sans", sans-serif !important;
 }
+
+i, em {
+	display: inline-block;
+}
+
+body .times-serif,
+body .texhtml,
+body .texhtml i,
+body .texhtml em,
+i::first-letter {
+	font-family: serif !important;
+	font-size: large;
+	font-weight: bold;
+}
+
+pre, pre *,
+code, code * {
+	font-family: "SFMono", Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
+}
+
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+    *, body {
+    	-webkit-font-smoothing: antialiased;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -3,17 +3,12 @@
 	font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue","Helvetica", "Nimbus Sans L", "Arial", "Liberation Sans", sans-serif !important;
 }
 
-i, em {
-	display: inline-block;
-}
-
 body .times-serif,
 body .texhtml,
 body .texhtml i,
-body .texhtml em,
-i::first-letter {
+body .texhtml em {
 	font-family: serif !important;
-	font-size: large;
+	font-size: larger;
 	font-weight: bold;
 }
 


### PR DESCRIPTION
Hi @jathu!

I found your m-wiki plugin in the chrome store a couple of weeks ago and have been using it ever since. Great plugin! Love the simplicity.

I noticed that a couple of styles were missing and thought that I'd add them.

What I've done in terms of readability is:
* Mathematical variables are now serif and bold (except for some ill formatted wiki pages, I'm going to try to find a solution for this but it seems to be impossible without js manipulation)
* Code segments are now displayed with a monospace font
* Antialiased font smoothing for retina displays

Functionality wise, it's basically one small change:
* Previously wiki pages with country codes ending with **m** wouldn't get detected (for example [**pam**.wikipedia.org/wiki/Isaaq_Niwuuten](https://pam.wikipedia.org/wiki/Isaac_Newton)
* Minor refactor


Let me know what you think.


**_Code before:_**
<img width="909" alt="skarmavbild 2016-11-18 kl 09 30 57" src="https://cloud.githubusercontent.com/assets/1241677/20503678/1bcf8080-b044-11e6-94bf-ca3b19c433e3.png">
<img width="931" alt="skarmavbild 2016-11-18 kl 09 30 04" src="https://cloud.githubusercontent.com/assets/1241677/20503909/204c6f28-b045-11e6-9a72-846f5ae597af.png">

**_Code after:_**
<img width="904" alt="skarmavbild 2016-11-18 kl 09 31 14" src="https://cloud.githubusercontent.com/assets/1241677/20503677/1bcb210c-b044-11e6-9bc5-52d8d88535cd.png">
<img width="912" alt="skarmavbild 2016-11-18 kl 09 29 41" src="https://cloud.githubusercontent.com/assets/1241677/20503910/204eac0c-b045-11e6-8792-8854471f43e4.png">



_**Inline math variables before:**_
<img width="926" alt="skarmavbild 2016-11-18 kl 09 09 27" src="https://cloud.githubusercontent.com/assets/1241677/20503851/d6f404da-b044-11e6-9fc8-73ab875affb1.png">
_**Inline math variables after:**_
<img width="911" alt="skarmavbild 2016-11-21 kl 23 46 44" src="https://cloud.githubusercontent.com/assets/1241677/20503852/d6fa7978-b044-11e6-9396-42db5b64a0af.png">

<img width="931" alt="skarmavbild 2016-11-18 kl 09 30 04" src="https://cloud.githubusercontent.com/assets/1241677/20503909/204c6f28-b045-11e6-9a72-846f5ae597af.png">

