### PR TITLE
Don't override font-family on body

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,5 @@
 *, body {
 	outline: none !important;
-	font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue","Helvetica", "Nimbus Sans L", "Arial", "Liberation Sans", sans-serif !important;
 }
 
 body .times-serif,


### PR DESCRIPTION
This will e.g. let the body be displayed in Segoe UI on Windows as expected.

I see that this was [added in 2016](https://github.com/jathu/m-wiki/commit/6dc1cb6#diff-da232d78aa810382f2dcdceae308ff8eR3) in order to let mac users see wikipedia in the then-new San Francisco. Since this is now the case in Wikipedia's mobile stylesheet, it's no longer necessary.